### PR TITLE
ISSUE-2: Bring back search

### DIFF
--- a/src/zondocs_theme/layout.html
+++ b/src/zondocs_theme/layout.html
@@ -55,6 +55,12 @@
     {%- endif %}
   {%- endblock %}
 
+  {% set script_files = script_files + ['_static/searchtools.js', '_static/language_data.js'] %}
+  {%- for scriptfile in script_files %}
+      {{ js_tag(scriptfile) }}
+    {%- endfor %}
+
+
   {%- block extrahead %} {% endblock %}
   </head>
   <body>
@@ -122,6 +128,7 @@
         {% include "footer.html" %}
       </div>
     </div>
+
     <script src="{{ pathto('_static/navigation.js', 1) }}"></script>
     <script src="{{ pathto('_static/navbutton.js', 1) }}"></script>
     <script src="{{ pathto('_static/builddate.js', 1) }}"></script>

--- a/src/zondocs_theme/static/theme.css
+++ b/src/zondocs_theme/static/theme.css
@@ -178,7 +178,7 @@ body {
   padding: 15px;
 }
 
-.search {
+.search__form  .search {
   background-color: var(--color-background);
   border: 1px solid var(--color-border);
   display: flex;


### PR DESCRIPTION
Ist ein Quickfix, der lokal erstmal funktioniert (aber einen so unglaublich traurig macht…)

- die Suche von Sphinx benötigt sowohl jQuery, als auch Underscore!
- aus irgendeinem Grund musste ich entgegen der Doku, zwei Dateien sselbst zu den Spkinx-Scripten adden (die aber aus Sphinx kommen), da scheint irgendwo noch ein Config-Haken zu stecken, aber den hab ich noch nicht gefunden
- lokal funktioniert's™ 

(und die Klassennamen sind dann auch noch nicht mal ordentlich voneinander abgegrenzt `.search` seufz)

![](https://media.tenor.com/cR82t3a8j0EAAAAd/homer-simpson-marge-simpson.gif)