### PR TITLE
DOC: definition lists need some margin

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,10 +2,12 @@
 CHANGES
 =======
 
-1.0.7 (unreleased)
+1.0.7 (2023-04-05)
 ------------------
 
-- Nothing changed yet.
+- Definition lists need some margin
+- Block quotes with better layout
+- Fix: Layout of field lists
 
 
 1.0.6 (2023-02-15)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def project_path(*names):
 
 setup(
     name='zondocs_theme',
-    version='1.0.6',
+    version='1.0.7',
 
     install_requires=[
         'setuptools',

--- a/src/zondocs_theme/static/theme.css
+++ b/src/zondocs_theme/static/theme.css
@@ -880,7 +880,7 @@ dl.footnote > dd {
 
 /* API */
 dl > dd {
-  margin: 20px 0;
+  margin-left: 30px;
 }
 
 dl > dd dd {

--- a/src/zondocs_theme/static/theme.css
+++ b/src/zondocs_theme/static/theme.css
@@ -905,6 +905,7 @@ dt.sig {
 
 .field-list dt,
 .field-list dd {
+  margin: 0;
   padding: 10px;
 }
 

--- a/src/zondocs_theme/static/theme.css
+++ b/src/zondocs_theme/static/theme.css
@@ -178,7 +178,7 @@ body {
   padding: 15px;
 }
 
-.search__form  .search {
+.search__form .search {
   background-color: var(--color-background);
   border: 1px solid var(--color-border);
   display: flex;
@@ -223,7 +223,7 @@ body {
 .navigation p {
   list-style: none;
   margin: 0;
-  padding:0;
+  padding: 0;
 }
 
 .navigation li.subnavi {
@@ -282,9 +282,9 @@ body {
 }
 
 /* haha! */
-.navigation li:has(.chevron + a:hover) > .chevron,
-.navigation li:has(.chevron--down) > .chevron,
-.navigation li:has(.chevron--down) > .chevron + a {
+.navigation li:has(.chevron + a:hover)>.chevron,
+.navigation li:has(.chevron--down)>.chevron,
+.navigation li:has(.chevron--down)>.chevron+a {
   background-color: var(--color-navigation-links-hover);
 }
 
@@ -396,30 +396,36 @@ body {
   stroke: currentColor;
   stroke-width: 6;
   transition: stroke-dasharray 600ms cubic-bezier(0.4, 0, 0.2, 1),
-  stroke-dashoffset 600ms cubic-bezier(0.4, 0, 0.2, 1);
+    stroke-dashoffset 600ms cubic-bezier(0.4, 0, 0.2, 1);
 }
+
 .navbutton .line1 {
   stroke-dasharray: 60 207;
   stroke-width: 6;
 }
+
 .navbutton .line2 {
   stroke-dasharray: 60 60;
   stroke-width: 6;
 }
+
 .navbutton .line3 {
   stroke-dasharray: 60 207;
   stroke-width: 6;
 }
+
 .navbutton[aria-expanded="true"] .line1 {
   stroke-dasharray: 90 207;
   stroke-dashoffset: -134;
   stroke-width: 6;
 }
+
 .navbutton[aria-expanded="true"] .line2 {
   stroke-dasharray: 1 60;
   stroke-dashoffset: -30;
   stroke-width: 6;
 }
+
 .navbutton[aria-expanded="true"] .line3 {
   stroke-dasharray: 90 207;
   stroke-dashoffset: -134;
@@ -445,7 +451,7 @@ body {
   display: contents;
 }
 
-.main > .contents > * {
+.main>.contents>* {
   grid-column: 2;
 }
 
@@ -591,6 +597,7 @@ code.literal {
   margin-bottom: 1em;
   padding: 10px;
 }
+
 .admonition::before {
   align-self: baseline;
   font-family: var(--font-stack-emojis);
@@ -745,12 +752,14 @@ code.literal {
 
 hr {
   border-color: var(--color-border);
-    border-style: solid;
+  border-style: solid;
   margin: 40px 0;
 }
 
 /* quotes */
 blockquote {
+  border-left: .25em solid var(--color-stiff-gray);
+  border-radius: .25rem;
   background-color: var(--color-module);
   box-sizing: content-box;
   margin: 40px 0;
@@ -758,13 +767,28 @@ blockquote {
   max-width: 100%;
 }
 
+blockquote,
+blockquote p {
+  color: var(--color-stiff-gray);
+}
+
+blockquote div>p+p.attribution {
+  font-style: normal;
+  font-size: .9em;
+  text-align: right;
+  color: var(--color-slate-gray);
+}
+
 /* code blocks */
-div[class^=highlight], pre.literal-block {
+div[class^=highlight],
+pre.literal-block {
   overflow-x: auto;
   margin: 1px 0 24px;
 }
 
-div[class^=highlight] pre, pre.literal-block, .linenodiv pre {
+div[class^=highlight] pre,
+pre.literal-block,
+.linenodiv pre {
   font-family: var(--font-stack-monospace);
   font-size: 0.875rem;
   line-height: 1.4;
@@ -794,7 +818,7 @@ div.highlight span.linenos {
   padding-left: 0;
   padding-right: 12px;
   margin-right: 12px;
-  border-right: 1px solid rgba(0, 0 , 0, 0.2);
+  border-right: 1px solid rgba(0, 0, 0, 0.2);
 }
 
 .code-block-caption {
@@ -805,7 +829,8 @@ div.highlight span.linenos {
 }
 
 /* inline styles */
-.citation-reference, .footnote-reference {
+.citation-reference,
+.footnote-reference {
   font-size: 90%;
   line-height: 0;
   position: relative;
@@ -823,7 +848,8 @@ div.highlight span.linenos {
 }
 
 /* kbd not darkmode */
-:not(dl.option-list)>:not(dt):not(kbd):not(.kbd)>.kbd, :not(dl.option-list)>:not(dt):not(kbd):not(.kbd)>kbd {
+:not(dl.option-list)>:not(dt):not(kbd):not(.kbd)>.kbd,
+:not(dl.option-list)>:not(dt):not(kbd):not(.kbd)>kbd {
   background-color: #fff;
   border: 1px solid #a6a6a6;
   border-radius: 4px;
@@ -855,18 +881,18 @@ dl.footnote {
 }
 
 dl.footnote,
-dl.footnote > dd p {
+dl.footnote>dd p {
   font-size: .9rem;
 }
 
-dl.footnote > dt {
+dl.footnote>dt {
   margin: 0 0.5rem 0.5rem 0;
   line-height: 1.2rem;
   word-break: break-all;
   font-weight: 400;
 }
 
-dl.footnote > dd {
+dl.footnote>dd {
   margin: 0 0 0.5rem;
   line-height: 1.2rem;
 }
@@ -874,16 +900,16 @@ dl.footnote > dd {
 /* local toc list */
 .local.topic ul.simple {
   background-color: var(--color-background-code);
-  border-left: 15px solid rgba(0,0,0, 0.2);
+  border-left: 15px solid rgba(0, 0, 0, 0.2);
   padding: 10px 10px 10px 2.7em;
 }
 
 /* API */
-dl > dd {
+dl>dd {
   margin-left: 30px;
 }
 
-dl > dd dd {
+dl>dd dd {
   margin: 0;
 }
 
@@ -988,7 +1014,9 @@ dt.sig {
   line-height: 18px;
 }
 
-.main table.docutils td p:last-child,.main table.field-list td p:last-child,.wy-table td p:last-child {
+.main table.docutils td p:last-child,
+.main table.field-list td p:last-child,
+.wy-table td p:last-child {
   margin-bottom: 0;
 }
 
@@ -1033,8 +1061,8 @@ dt.sig {
   border-left: 1px solid var(--color-border);
 }
 
-.main table.docutils tbody > tr:last-child td,
-.wy-table-bordered-all tbody > tr:last-child td {
+.main table.docutils tbody>tr:last-child td,
+.wy-table-bordered-all tbody>tr:last-child td {
   border-bottom-width: 0;
 }
 
@@ -1046,7 +1074,7 @@ dt.sig {
   border-bottom: 1px solid var(--color-border);
 }
 
-.wy-table-bordered-rows tbody > tr:last-child td {
+.wy-table-bordered-rows tbody>tr:last-child td {
   border-bottom-width: 0;
 }
 
@@ -1056,7 +1084,7 @@ dt.sig {
   border-bottom: 1px solid var(--color-border);
 }
 
-.wy-table-horizontal tbody > tr:last-child td {
+.wy-table-horizontal tbody>tr:last-child td {
   border-bottom-width: 0;
 }
 
@@ -1067,7 +1095,7 @@ dt.sig {
 }
 
 .wy-table-responsive table {
-  margin-bottom: 0!important;
+  margin-bottom: 0 !important;
 }
 
 .wy-table-responsive table td,


### PR DESCRIPTION
[Glossar](https://docs.zeit.de/faq/glossary.html) ist ziemlich unübersichtlich ohne margin, daher dieser PR.

Vorher:

<img width="411" alt="grafik" src="https://user-images.githubusercontent.com/121817095/221638380-5d7700cd-c0c3-489d-9f28-729718cbef15.png">

Nachher:

<img width="411" alt="grafik" src="https://user-images.githubusercontent.com/121817095/221639137-8797fce1-9c0e-475d-81d5-6895d52dcd9f.png">

